### PR TITLE
Añadir modelo PhotoComp

### DIFF
--- a/Concepts.xcodeproj/project.pbxproj
+++ b/Concepts.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		DDAE17D82B8D4CAD000EC9FE /* ConceptsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17D72B8D4CAD000EC9FE /* ConceptsTests.swift */; };
 		DDAE17E22B8D4CAD000EC9FE /* ConceptsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17E12B8D4CAD000EC9FE /* ConceptsUITests.swift */; };
 		DDAE17E42B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17E32B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift */; };
+		DDE2C5CE2BA1187100CB046A /* PhotoComp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2C5CD2BA1187100CB046A /* PhotoComp.swift */; };
+		DDE2C5D12BA11CA900CB046A /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2C5D02BA11CA900CB046A /* CodeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +54,8 @@
 		DDAE17DD2B8D4CAD000EC9FE /* ConceptsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConceptsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDAE17E12B8D4CAD000EC9FE /* ConceptsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptsUITests.swift; sourceTree = "<group>"; };
 		DDAE17E32B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		DDE2C5CD2BA1187100CB046A /* PhotoComp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoComp.swift; sourceTree = "<group>"; };
+		DDE2C5D02BA11CA900CB046A /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +108,9 @@
 			children = (
 				DDAE17C62B8D4CAC000EC9FE /* ConceptsApp.swift */,
 				DDAE17C82B8D4CAC000EC9FE /* ContentView.swift */,
+				DDE2C5CF2BA11C7D00CB046A /* Utilities */,
 				A404BB3A2B9C19DC00D2BED9 /* ConceptsModel.swift */,
+				DDE2C5CC2BA1185600CB046A /* Models */,
 				A404BB3C2B9C1EF000D2BED9 /* ConceptsRowView.swift */,
 				A404BB3E2B9C2CC200D2BED9 /* ConceptsListView.swift */,
 				A404BB402B9C375500D2BED9 /* ConceptsListDetailView.swift */,
@@ -137,6 +143,22 @@
 				DDAE17E32B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift */,
 			);
 			path = ConceptsUITests;
+			sourceTree = "<group>";
+		};
+		DDE2C5CC2BA1185600CB046A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				DDE2C5CD2BA1187100CB046A /* PhotoComp.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		DDE2C5CF2BA11C7D00CB046A /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				DDE2C5D02BA11CA900CB046A /* CodeView.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -273,8 +295,10 @@
 				DDAE17C92B8D4CAC000EC9FE /* ContentView.swift in Sources */,
 				A404BB3B2B9C19DC00D2BED9 /* ConceptsModel.swift in Sources */,
 				A404BB3D2B9C1EF000D2BED9 /* ConceptsRowView.swift in Sources */,
+				DDE2C5CE2BA1187100CB046A /* PhotoComp.swift in Sources */,
 				A404BB3F2B9C2CC200D2BED9 /* ConceptsListView.swift in Sources */,
 				DDAE17C72B8D4CAC000EC9FE /* ConceptsApp.swift in Sources */,
+				DDE2C5D12BA11CA900CB046A /* CodeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Concepts/Models/PhotoComp.swift
+++ b/Concepts/Models/PhotoComp.swift
@@ -1,0 +1,90 @@
+//
+//  PhotoComp.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 12/03/24.
+//
+
+import SwiftUI
+
+struct PhotoComp: Identifiable, Codable {
+    var id = UUID()
+    var nombre: String
+    var detalle: String
+    var historia: String
+    var teoria: String
+    var ejemplos: [String]  // Nombres de archivo de imagen para los ejemplos
+    var overlay: String     // Nombre de archivo de imagen para el overlay
+    var icon: String        // Nombre de archivo de imagen para el ícono
+    
+    // MARK: - Solo para mostrar el uso (Ejemplos)
+    fileprivate static let examples = [
+        PhotoComp(nombre: "Regla de Tercios", detalle: "Divide el marco en tres partes horizontales y verticales.", historia: "Historia de la regla de tercios...", teoria: "Teoría de la regla de tercios...", ejemplos: ["ejemplo1.jpg"], overlay: "overlay1.jpg", icon: "icon1.jpg"),
+        PhotoComp(nombre: "Marco Natural", detalle: "Utiliza elementos naturales como árboles para enmarcar.", historia: "Historia del marco natural...", teoria: "Teoría del marco natural...", ejemplos: ["ejemplo2.jpg"], overlay: "overlay2.jpg", icon: "icon2.jpg")
+    ]
+}
+
+// MARK: - PhotoComp documentation view
+fileprivate struct DocumantationPhotoCompView: View {
+    var body: some View {
+        VStack {
+            Text("Ejemplo de lista de comp")
+                            .font(.title)
+                            .bold()
+                            .padding()
+            List(PhotoComp.examples) { comp in
+                HStack {
+                    Image(systemName: "photo")
+                        .frame(width: 50, height: 50)
+                    VStack(alignment: .leading) {
+                        Text(comp.nombre).font(.headline)
+                        Text(comp.detalle).font(.subheadline)
+                    }
+                }
+            }
+            Text("Definición de PhotoComp")
+                            .font(.title)
+                            .bold()
+                            .padding()
+            ScrollView {
+                CodeView(code: """
+                    struct PhotoComp: Identifiable, Codable {
+                            var id = UUID()
+                            var nombre: String
+                            var detalle: String
+                            var historia: String
+                            var teoria: String
+                            var ejemplos: [String]
+                            var overlay: String
+                            var icon: String
+                    }
+                    """)
+
+                Text("Ejemplos de Uso")
+                    .font(.title2)
+                    .bold()
+                    .padding()
+
+                CodeView(code: """
+                let ejemploPhotoComp = PhotoComp(
+                    nombre: "Regla de Tercios",
+                    detalle: "Detalles de la regla de tercios...",
+                    historia: "Historia de la regla de tercios...",
+                    teoria: "Teoría detrás de la regla de tercios...",
+                    ejemplos: ["imagen1.jpg", "imagen2.jpg"],
+                    overlay: "overlay.jpg",
+                    icon: "icon1.jpg"
+                )
+                """)
+
+
+            }
+        }
+    }
+}
+
+struct PhotoCompView_Previews: PreviewProvider {
+    static var previews: some View {
+        DocumantationPhotoCompView()
+    }
+}

--- a/Concepts/Utilities/CodeView.swift
+++ b/Concepts/Utilities/CodeView.swift
@@ -1,0 +1,22 @@
+//
+//  CodeView.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 12/03/24.
+//
+
+import SwiftUI
+
+// MARK: - Code View
+struct CodeView: View {
+    var code: String
+
+    var body: some View {
+        Text(code)
+            .font(.system(.body, design: .monospaced))
+            .foregroundColor(.blue)
+            .padding()
+            .background(Color.gray.opacity(0.2))
+            .cornerRadius(8)
+    }
+}


### PR DESCRIPTION

#### Descripción
Este Pull Request introduce el modelo `PhotoComp`, diseñado para representar composiciones fotográficas con detalles completos incluyendo nombre, detalle, historia, teoría, ejemplos, overlay, e icono.

#### Cambios realizados
- Se ha añadido el struct `PhotoComp` con los siguientes campos:
  - `nombre`: String
  - `detalle`: String
  - `historia`: String
  - `teoria`: String
  - `ejemplos`: [String]
  - `overlay`: String
  - `icon`: String

#### Motivación y contexto
La estructura `PhotoComp` se introduce para proporcionar una representación detallada de las composiciones fotográficas, facilitando así la gestión y visualización de la información relevante en la aplicación.

#### Cómo probar los cambios
- Verificar la creación de instancias de `PhotoComp` con datos de prueba.
- Implementar `PhotoComp` en vistas SwiftUI para confirmar la visualización correcta de los datos.

#### Capturas de pantalla
Correr preview en archivo PhotoComp.swift
