### PR TITLE
Se agrega cameraView

### DIFF
--- a/Concepts.xcodeproj/project.pbxproj
+++ b/Concepts.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		DDAE17D82B8D4CAD000EC9FE /* ConceptsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17D72B8D4CAD000EC9FE /* ConceptsTests.swift */; };
 		DDAE17E22B8D4CAD000EC9FE /* ConceptsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17E12B8D4CAD000EC9FE /* ConceptsUITests.swift */; };
 		DDAE17E42B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE17E32B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift */; };
+		DDE204112BA8E56B00FE9216 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE204102BA8E56B00FE9216 /* OrientationManager.swift */; };
+		DDE204132BA8E5D300FE9216 /* PhotoCompositionCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE204122BA8E5D300FE9216 /* PhotoCompositionCameraView.swift */; };
+		DDE204152BA8E5F500FE9216 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE204142BA8E5F500FE9216 /* CameraView.swift */; };
+		DDE204192BA8F6E000FE9216 /* CameraAccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE204182BA8F6E000FE9216 /* CameraAccessView.swift */; };
 		DDE2C5CE2BA1187100CB046A /* PhotoComp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2C5CD2BA1187100CB046A /* PhotoComp.swift */; };
 		DDE2C5D12BA11CA900CB046A /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2C5D02BA11CA900CB046A /* CodeView.swift */; };
 /* End PBXBuildFile section */
@@ -56,6 +60,10 @@
 		DDAE17DD2B8D4CAD000EC9FE /* ConceptsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConceptsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDAE17E12B8D4CAD000EC9FE /* ConceptsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptsUITests.swift; sourceTree = "<group>"; };
 		DDAE17E32B8D4CAD000EC9FE /* ConceptsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		DDE204102BA8E56B00FE9216 /* OrientationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.swift; sourceTree = "<group>"; };
+		DDE204122BA8E5D300FE9216 /* PhotoCompositionCameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCompositionCameraView.swift; sourceTree = "<group>"; };
+		DDE204142BA8E5F500FE9216 /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
+		DDE204182BA8F6E000FE9216 /* CameraAccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAccessView.swift; sourceTree = "<group>"; };
 		DDE2C5CD2BA1187100CB046A /* PhotoComp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoComp.swift; sourceTree = "<group>"; };
 		DDE2C5D02BA11CA900CB046A /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -99,6 +107,7 @@
 			isa = PBXGroup;
 			children = (
 				DD411B082BA3A612001AAA76 /* PhotoCompDetailView.swift */,
+				DDE204122BA8E5D300FE9216 /* PhotoCompositionCameraView.swift */,
 			);
 			path = DetailView;
 			sourceTree = "<group>";
@@ -176,6 +185,9 @@
 			children = (
 				DDE2C5D02BA11CA900CB046A /* CodeView.swift */,
 				DD411B0C2BA41AAA001AAA76 /* CompositionManager.swift */,
+				DDE204102BA8E56B00FE9216 /* OrientationManager.swift */,
+				DDE204142BA8E5F500FE9216 /* CameraView.swift */,
+				DDE204182BA8F6E000FE9216 /* CameraAccessView.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -313,11 +325,15 @@
 				DDAE17C92B8D4CAC000EC9FE /* ContentView.swift in Sources */,
 				A404BB3B2B9C19DC00D2BED9 /* ConceptsModel.swift in Sources */,
 				A404BB3D2B9C1EF000D2BED9 /* ConceptsRowView.swift in Sources */,
+				DDE204152BA8E5F500FE9216 /* CameraView.swift in Sources */,
 				DDE2C5CE2BA1187100CB046A /* PhotoComp.swift in Sources */,
 				A404BB3F2B9C2CC200D2BED9 /* ConceptsListView.swift in Sources */,
 				DD411B092BA3A612001AAA76 /* PhotoCompDetailView.swift in Sources */,
 				DDAE17C72B8D4CAC000EC9FE /* ConceptsApp.swift in Sources */,
 				DD411B0D2BA41AAA001AAA76 /* CompositionManager.swift in Sources */,
+				DDE204112BA8E56B00FE9216 /* OrientationManager.swift in Sources */,
+				DDE204192BA8F6E000FE9216 /* CameraAccessView.swift in Sources */,
+				DDE204132BA8E5D300FE9216 /* PhotoCompositionCameraView.swift in Sources */,
 				DDE2C5D12BA11CA900CB046A /* CodeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -405,6 +421,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -459,6 +476,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -480,11 +498,11 @@
 				DEVELOPMENT_TEAM = 7J77M7XTN8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Necesitamos la camara para que puedas hacer uso de nuestros overlays";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -509,11 +527,11 @@
 				DEVELOPMENT_TEAM = 7J77M7XTN8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Necesitamos la camara para que puedas hacer uso de nuestros overlays";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Concepts.xcodeproj/xcuserdata/rodolfocastillo.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Concepts.xcodeproj/xcuserdata/rodolfocastillo.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "DDC80B44-2DAE-4D21-8878-3AC9BBA0866B"
+   type = "1"
+   version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "B40406E2-1BA4-45E8-8D1A-F4624FC375EF"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Concepts/DetailView/PhotoCompositionCameraView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "9"
+            endingLineNumber = "9"
+            landmarkName = "unknown"
+            landmarkType = "0">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "EC09ECEE-D7EF-4198-92E7-6DBD7AA35449"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Concepts/DetailView/PhotoCompDetailView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "16"
+            endingLineNumber = "16"
+            landmarkName = "body"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "0A580551-E82D-48D5-82E2-13132C303AD8"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Concepts/DetailView/PhotoCompositionCameraView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "14"
+            endingLineNumber = "14"
+            landmarkName = "init(overlayName:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
+</Bucket>

--- a/Concepts/DetailView/PhotoCompDetailView.swift
+++ b/Concepts/DetailView/PhotoCompDetailView.swift
@@ -1,10 +1,36 @@
 import SwiftUI
 
 struct PhotoCompDetailView: View {
+    
+    @ObservedObject var orientationManager = OrientationManager.shared
+    @State private var image: UIImage?
+    @State private var showCamera = false
+    
     var photoComp: PhotoComp
 
     var body: some View {
-        GeometryReader { reader in
+        CameraAccessView()
+           Group {
+               if orientationManager.orientation.isLandscape {
+                   // Tu vista de cámara aquí
+                   PhotoCompositionCameraView(overlayName: photoComp.overlay.first ?? "")
+               } else {
+                   // Otra vista para orientación vertical
+                   portraitView()
+               }
+           }
+           .onAppear {
+               UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+           }
+           .onDisappear {
+               UIDevice.current.endGeneratingDeviceOrientationNotifications()
+           }
+       }
+}
+
+extension PhotoCompDetailView {
+    func portraitView() -> some View {
+        return GeometryReader { reader in
             let overlayWidth = reader.size.width - 30
             let overlayHeight = overlayWidth * (2/3)
             ScrollView {
@@ -21,12 +47,10 @@ struct PhotoCompDetailView: View {
                                 Image(overlay)
                                     .resizable()
                                     .scaledToFit()
-                                    .padding(.bottom)
                                     .background(Color.gray.opacity(0.3))
                                     // Aquí defines el tamaño de cada imagen directamente
                                     .frame(height: overlayHeight - 10)
                                     .cornerRadius(10)
-                                    .padding(EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
                             }
                         }
                         .padding(.horizontal)

--- a/Concepts/DetailView/PhotoCompositionCameraView.swift
+++ b/Concepts/DetailView/PhotoCompositionCameraView.swift
@@ -1,0 +1,40 @@
+//
+//  PhotoCompositionCameraView.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 18/03/24.
+//
+
+import SwiftUI
+
+struct PhotoCompositionCameraView: View {
+    private var overlayName: String = ""
+    
+    init(overlayName: String) {
+        self.overlayName = overlayName
+    }
+
+    var body: some View {
+        GeometryReader { reader in
+            let width = reader.size.width
+            let height = width * 3/2
+            ZStack {
+                CameraView().toolbar(.hidden, for: .navigationBar)
+                Image(overlayName)                
+                    .resizable()
+                    .scaledToFit()
+                    .rotationEffect(.degrees(90)) // Rota la imagen 90 grados
+                    .frame(width: width, height: height)
+                    .clipped()
+            }.ignoresSafeArea(.all, edges: .all)
+        }
+    }
+}
+
+struct PhotoCompositionCameraView_Previews: PreviewProvider {
+    static var previews: some View {
+        PhotoCompositionCameraView(overlayName: CompositionManager.shared.compositions.randomElement()?.overlay.randomElement() ?? "goldenRatio")
+    }
+}
+
+

--- a/Concepts/Utilities/CameraAccessView.swift
+++ b/Concepts/Utilities/CameraAccessView.swift
@@ -1,0 +1,53 @@
+//
+//  CameraAccessView.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 18/03/24.
+//
+
+import SwiftUI
+import AVFoundation
+
+struct CameraAccessView: View {
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
+
+    var body: some View {
+        VStack {
+            // Tu contenido aquí
+        }
+        .onAppear {
+            checkCameraAccess()
+        }
+        .alert(isPresented: $showingAlert) {
+            Alert(
+                title: Text("Permiso de Cámara Requerido"),
+                message: Text(alertMessage),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+    
+    func checkCameraAccess() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            // El usuario ha autorizado el acceso, continuar con la funcionalidad
+            break
+        case .notDetermined:
+            // Permiso no determinado, solicitar acceso
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                if !granted {
+                    alertMessage = "No puedes usar esta funcionalidad sin conceder acceso a la cámara. Por favor, habilita el acceso en la Configuración de tu dispositivo."
+                    showingAlert = true
+                }
+            }
+        case .denied, .restricted:
+            // El usuario ha denegado el acceso previamente o está restringido
+            alertMessage = "El acceso a la cámara ha sido denegado. Por favor, habilita el acceso en la Configuración de tu dispositivo para usar esta funcionalidad."
+            showingAlert = true
+        @unknown default:
+            break
+        }
+    }
+}
+

--- a/Concepts/Utilities/CameraView.swift
+++ b/Concepts/Utilities/CameraView.swift
@@ -1,0 +1,62 @@
+//
+//  CameraView.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 18/03/24.
+//
+
+import SwiftUI
+import AVFoundation
+
+struct CameraView: UIViewRepresentable {
+    class Coordinator: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+        var parent: CameraView
+
+        init(parent: CameraView) {
+            self.parent = parent
+        }
+
+        // Implementar el manejo de frames de video aquí
+        func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+            // Procesar el frame del video
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: UIScreen.main.bounds)
+
+        // Configurar la sesión de captura
+        let captureSession = AVCaptureSession()
+        guard let captureDevice = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: captureDevice) else {
+            return view
+        }
+
+        if captureSession.canAddInput(input) {
+            captureSession.addInput(input)
+        }
+
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+        previewLayer.frame = view.frame
+        previewLayer.videoGravity = .resizeAspectFill
+        view.layer.addSublayer(previewLayer)
+
+        captureSession.startRunning()
+
+        // Configura la salida de video para procesamiento de frames
+        let output = AVCaptureVideoDataOutput()
+        output.setSampleBufferDelegate(context.coordinator, queue: DispatchQueue(label: "videoQueue"))
+        if captureSession.canAddOutput(output) {
+            captureSession.addOutput(output)
+        }
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+

--- a/Concepts/Utilities/OrientationManager.swift
+++ b/Concepts/Utilities/OrientationManager.swift
@@ -1,0 +1,26 @@
+//
+//  OrientationManager.swift
+//  Concepts
+//
+//  Created by Rodolfo Castillo on 18/03/24.
+//
+
+import SwiftUI
+import Combine
+
+class OrientationManager: ObservableObject {
+    static let shared = OrientationManager()
+    
+    @Published var orientation: UIDeviceOrientation = .portrait
+    
+    private init() {
+        self.orientation = UIDevice.current.orientation
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(didChangeOrientation), name: UIDevice.orientationDidChangeNotification, object: nil)
+    }
+    
+    @objc private func didChangeOrientation() {
+        self.orientation = UIDevice.current.orientation
+    }
+}
+

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
Descripción del Cambio
Este PR introduce varias mejoras y nuevas funcionalidades en nuestra aplicación, centradas en la implementación de una vista de cámara personalizada y el manejo avanzado de imágenes. Se incluyen los siguientes cambios principales:

Creación de CameraView, una vista de cámara construida desde cero utilizando AVFoundation.
Implementación de FullScreenRotatedImageView para mostrar imágenes en pantalla completa con rotación y ajustes específicos.
Ajustes en la vista para que ignore el área segura inferior, permitiendo que la imagen ocupe toda la pantalla.
Añadido soporte para relaciones de aspecto específicas en imágenes, basándose en un ancho conocido.
Motivación y Contexto
La necesidad de ofrecer una experiencia de usuario más rica y personalizada en nuestra aplicación nos llevó a desarrollar una vista de cámara totalmente personalizada, que nos permite un mayor control sobre la captura y presentación de imágenes. Además, ajustar la visualización de imágenes para ocupar toda la pantalla y manejar relaciones de aspecto específicas mejora la coherencia visual y la usabilidad de la aplicación.

Implementación
CameraView: Se utilizó AVFoundation para acceder y controlar la cámara del dispositivo, proporcionando una base para futuras expansiones y características personalizadas.
FullScreenRotatedImageView: Implementa un contenedor GeometryReader con ZStack para ajustar y rotar imágenes según sea necesario, incluyendo la expansión para ignorar las áreas seguras.
Relación de aspecto 2:3: Se añadió lógica para calcular el alto de las imágenes basándose en un ancho dado, manteniendo una relación de aspecto de 2:3.
Cómo Probar
Navegar a la vista de cámara desde la interfaz principal de la aplicación.
Capturar una imagen y observar cómo se presenta en la vista de rotación completa.
Verificar que la imagen ignore correctamente el área segura inferior en dispositivos con pantallas de borde a borde.
Asegurar que las imágenes ajustadas a una relación de aspecto de 2:3 se muestren correctamente basándose en el ancho proporcionado.